### PR TITLE
fix(web): prevent crash on session delete due to async PTY output

### DIFF
--- a/lib/commands/web.js
+++ b/lib/commands/web.js
@@ -303,7 +303,10 @@ async function webCommand(options) {
     ptyManager.onExit(() => {
       logger.info(`Session ${id} (${session.name}) exited.`);
       clearTimeout(session.completionTimer);
-      if (session.renderedHistory) session.renderedHistory.dispose();
+      if (session.renderedHistory) {
+        session.renderedHistory.dispose();
+        session.renderedHistory = null;
+      }
       sessions.delete(id);
       broadcastToSession(id, { type: 'exit' });
     });
@@ -363,7 +366,10 @@ async function webCommand(options) {
     if (session) {
       clearTimeout(session.completionTimer);
       logSessionDiagnostics('session-deleted', session, {}, { compact: true });
-      if (session.renderedHistory) session.renderedHistory.dispose();
+      if (session.renderedHistory) {
+        session.renderedHistory.dispose();
+        session.renderedHistory = null;
+      }
       session.ptyManager.kill();
       sessions.delete(req.params.id);
     }

--- a/lib/session/rendered-history.js
+++ b/lib/session/rendered-history.js
@@ -38,6 +38,7 @@ class RenderedHistory {
   }
 
   write(data) {
+    if (!this.term) return;
     if (!data) return;
     const text = String(data);
     this.totalWrites += 1;
@@ -52,6 +53,7 @@ class RenderedHistory {
   }
 
   resize(cols, rows) {
+    if (!this.term) return;
     const rawCols = Number.parseInt(cols, 10);
     const rawRows = Number.parseInt(rows, 10);
     const nextCols = Math.max(2, rawCols || this.cols);


### PR DESCRIPTION
When a session is deleted, the underlying node-pty process may still asynchronously emit terminal data before fully terminating. If the renderedHistory object was disposed but not nullified, accessing its disposed 'term' property caused an unhandled TypeError, leading to an application crash. Added defensive checks in RenderedHistory and explicit nullification of the reference on session disposal.

# Description

Please include a summary of the changes and which issue is fixed. Include relevant motivation and context.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Tested on macOS
- [ ] Tested on Linux
- [ ] Tested on Windows
- [ ] Tested with multiple AI tools

**Test Configuration:**
- Node.js version:
- OS:
- AI tools tested:

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have tested my changes locally
- [ ] I have updated project docs if implementation details changed
- [ ] I have updated README.md if user-facing changes were made

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

Add any other notes about the PR here.
